### PR TITLE
Fix `jdbc-source` to use the proper config props

### DIFF
--- a/source/jdbc-source/pom.xml
+++ b/source/jdbc-source/pom.xml
@@ -41,6 +41,11 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-json</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/source/jdbc-source/src/test/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceIntegrationTests.java
+++ b/source/jdbc-source/src/test/java/org/springframework/cloud/stream/app/jdbc/source/JdbcSourceIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,20 +22,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.cloud.stream.binder.test.TestChannelBinderConfiguration;
-import org.springframework.cloud.stream.config.BindingServiceConfiguration;
 import org.springframework.cloud.stream.test.binder.MessageCollector;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
 
-@SpringBootTest(properties = {"spring.datasource.url=jdbc:h2:mem:test","spring.cloud.stream.function.definition=jdbcSupplier"},
-		webEnvironment = SpringBootTest.WebEnvironment.NONE)
+/**
+ * @author Soby Chacko
+ * @author Artem Bilan
+ */
+@SpringBootTest(properties = "spring.cloud.stream.function.definition=jdbcSupplier")
 @DirtiesContext
 public class JdbcSourceIntegrationTests {
 
-	protected final ObjectMapper objectMapper = new ObjectMapper();
+	@Autowired
+	protected ObjectMapper objectMapper;
 
 	@Qualifier("jdbcSupplier-out-0")
 	@Autowired
@@ -48,6 +50,7 @@ public class JdbcSourceIntegrationTests {
 	protected MessageCollector messageCollector;
 
 	@SpringBootApplication
-	@Import({JdbcSupplierConfiguration.class})
-	public static class JdbcSourceConfiguration {}
+	@Import(JdbcSupplierConfiguration.class)
+	public static class JdbcSourceConfiguration { }
+
 }

--- a/source/jdbc-source/src/test/java/org/springframework/cloud/stream/app/jdbc/source/Select2PerPollNoSplitWithUpdateTests.java
+++ b/source/jdbc-source/src/test/java/org/springframework/cloud/stream/app/jdbc/source/Select2PerPollNoSplitWithUpdateTests.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 
 import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.messaging.Message;
 import org.springframework.test.context.TestPropertySource;
@@ -31,17 +30,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+/**
+ * @author Soby Chacko
+ * @author Artem Bilan
+ */
 @TestPropertySource(properties = {
-			"jdbc.supplier.query=select id, name, tag from test where tag is NULL order by id",
-			"jdbc.supplier.split=false",
-			"jdbc.supplier.maxRows=2",
-			"jdbc.supplier.update=update test set tag='1' where id in (:id)" })
+		"jdbc.supplier.query=select id, name, tag from test where tag is NULL order by id",
+		"jdbc.supplier.split=false",
+		"jdbc.supplier.maxRows=2",
+		"jdbc.supplier.update=update test set tag='1' where id in (:id)" })
 public class Select2PerPollNoSplitWithUpdateTests extends JdbcSourceIntegrationTests {
 
 	@Test
-	@Disabled
 	public void testExtraction() throws Exception {
-		Message<?> received = messageCollector.forChannel(output).poll(10, TimeUnit.SECONDS);
+		Message<?> received = this.messageCollector.forChannel(this.output).poll(10, TimeUnit.SECONDS);
 		assertNotNull(received);
 		assertThat(received.getPayload().getClass()).isEqualTo(String.class);
 
@@ -53,10 +55,11 @@ public class Select2PerPollNoSplitWithUpdateTests extends JdbcSourceIntegrationT
 		assertEquals(2, payload.size());
 		assertEquals(1, payload.get(0).get("ID"));
 		assertEquals(2, payload.get(1).get("ID"));
-		received = messageCollector.forChannel(output).poll(10, TimeUnit.SECONDS);
+		received = this.messageCollector.forChannel(this.output).poll(10, TimeUnit.SECONDS);
 		assertNotNull(received);
 		payload = this.objectMapper.readValue((String) received.getPayload(), valueType);
 		assertEquals(1, payload.size());
 		assertEquals(3, payload.get(0).get("ID"));
 	}
+
 }

--- a/source/jdbc-source/src/test/java/org/springframework/cloud/stream/app/jdbc/source/SelectAllNoSplitTests.java
+++ b/source/jdbc-source/src/test/java/org/springframework/cloud/stream/app/jdbc/source/SelectAllNoSplitTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@TestPropertySource(properties = { "jdbc.supplier.query=select id, name, tag from test where tag is NULL order by id", "jdbc.split=false" })
+/**
+ * @author Soby Chacko
+ * @author Artem Bilan
+ */
+@TestPropertySource(properties = {
+		"jdbc.supplier.query=select id, name, tag from test where tag is NULL order by id",
+		"jdbc.supplier.split=false"
+})
 public class SelectAllNoSplitTests extends JdbcSourceIntegrationTests {
 
 	@Test
@@ -48,4 +55,5 @@ public class SelectAllNoSplitTests extends JdbcSourceIntegrationTests {
 		assertEquals(1, payload.get(0).get("ID"));
 		assertEquals("John", payload.get(2).get("NAME"));
 	}
+
 }


### PR DESCRIPTION
The `jdbc-supplier` relied on the wrong properties for conditions

* Now since that has been fixed, the tests for this `jdbc-source`
are fixed accordingly
* Failed test is enabled back
* Add `spring-boot-starter-json` to allow tests to use an auto-configured
`ObjectMapper` instead of an explicit instantiation